### PR TITLE
Many changes related to saving tasks:

### DIFF
--- a/lib/src/core/tasks/task_manager.dart
+++ b/lib/src/core/tasks/task_manager.dart
@@ -342,16 +342,18 @@ class TaskManager with ChangeNotifier {
     }
   }
 
-  Future saveTask(Task task, {String? filePath}) async {
-    return await saveTasks([task], filePath: filePath);
+  Future saveTask(Task task, {String? filePath, String? saveMarker}) async {
+    return await saveTasks([task], filePath: filePath, saveMarker: saveMarker);
   }
 
-  Future saveTasks(List<Task> tasks, {String? filePath}) async {
+  Future saveTasks(List<Task> tasks,
+      {String? filePath, String? saveMarker}) async {
     var fileIndex = filePath == null ? tasks[0].taskSource!.fileNumber : 0;
     var content = await TaskSaver(storage).saveTasks(tasks,
         filePath: filePath,
         dateTemplate: dateTemplate,
-        taskFilter: _taskFilter);
+        taskFilter: _taskFilter,
+        saveMarker: saveMarker);
 
     if (content != null) {
       var fileName = filePath ?? tasks[0].taskSource!.fileName;

--- a/lib/src/screens/settings/settings_service.dart
+++ b/lib/src/screens/settings/settings_service.dart
@@ -36,6 +36,10 @@ class SettingsService {
       "review_tasks_reminder_time";
   static const String _reviewCompletedReminderTimeKey =
       "review_completed_reminder_time";
+  static const String _saveMarkerKey = "save_marker";
+  static const String _chooseFileEnabledKey = "choose_file_enabled";
+  static const String _lastSelectedFileKey = "last_selected_file";
+  static const String _filePathPatternKey = "file_path_pattern";
 
   Future<ThemeMode> themeMode() async => ThemeMode.system;
 
@@ -306,6 +310,58 @@ class SettingsService {
       sharedPreferences.remove(_chatGptKeyKey);
     } else {
       sharedPreferences.setString(_chatGptKeyKey, chatGptKey);
+    }
+  }
+
+  Future<String?> saveMarker() async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    return sharedPreferences.getString(_saveMarkerKey);
+  }
+
+  Future<void> updateSaveMarker(String? saveMarker) async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    if (saveMarker == null) {
+      sharedPreferences.remove(_saveMarkerKey);
+    } else {
+      sharedPreferences.setString(_saveMarkerKey, saveMarker);
+    }
+  }
+
+  Future<bool> chooseFileEnabled() async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    return sharedPreferences.getBool(_chooseFileEnabledKey) ?? false;
+  }
+
+  Future<void> updateChooseFileEnabled(bool value) async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    sharedPreferences.setBool(_chooseFileEnabledKey, value);
+  }
+
+  Future<String?> lastSelectedFile() async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    return sharedPreferences.getString(_lastSelectedFileKey);
+  }
+
+  Future<void> updateLastSelectedFile(String? filePath) async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    if (filePath == null) {
+      sharedPreferences.remove(_lastSelectedFileKey);
+    } else {
+      sharedPreferences.setString(_lastSelectedFileKey, filePath);
+    }
+  }
+
+  Future<String?> filePathPattern() async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    return sharedPreferences.getString(_filePathPatternKey);
+  }
+
+  Future<void> updateFilePathPattern(String? pattern) async {
+    var sharedPreferences = await SharedPreferences.getInstance();
+    if (pattern == null) {
+      sharedPreferences.remove(_filePathPatternKey);
+    } else {
+      sharedPreferences.setString(_filePathPatternKey, pattern);
     }
   }
 }

--- a/lib/src/screens/settings/settings_view.dart
+++ b/lib/src/screens/settings/settings_view.dart
@@ -31,12 +31,16 @@ class _SettingsViewState extends State<SettingsView> {
   final _dateTemplateController = TextEditingController();
   final _tasksFileNameController = TextEditingController();
   final _globalTaskFilterController = TextEditingController();
+  final _saveMarkerController = TextEditingController();
+  final _filePathPatternController = TextEditingController();
 
   @override
   void initState() {
     _dateTemplateController.text = widget.controller.dateTemplate;
     _tasksFileNameController.text = widget.controller.tasksFile;
     _globalTaskFilterController.text = widget.controller.globalTaskFilter;
+    _saveMarkerController.text = widget.controller.saveMarker ?? '';
+    _filePathPatternController.text = widget.controller.filePathPattern ?? '';
 
     _dateTemplateController.addListener(() {
       widget.controller.updateDateTemplate(_dateTemplateController.text);
@@ -59,6 +63,8 @@ class _SettingsViewState extends State<SettingsView> {
     _tasksFileNameController.dispose();
     _dateTemplateController.dispose();
     _globalTaskFilterController.dispose();
+    _saveMarkerController.dispose();
+    _filePathPatternController.dispose();
     widget.controller.removeListener(_onControllerChanged);
     super.dispose();
   }
@@ -139,6 +145,57 @@ class _SettingsViewState extends State<SettingsView> {
                     widget.controller.updateGlobalTaskFilter(value);
                   },
                 )
+              ])),
+          Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(children: [
+                const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text("Save Marker (for file selection): ")),
+                TextField(
+                  controller: _saveMarkerController,
+                  decoration: const InputDecoration(
+                    hintText: "Enter a marker, e.g. <!-- tasks -->",
+                  ),
+                  onSubmitted: (value) {
+                    widget.controller
+                        .updateSaveMarker(value.isEmpty ? null : value);
+                  },
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  "When 'Choose file' is enabled, new tasks will be inserted after this marker in the selected file.",
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Colors.grey[600],
+                  ),
+                ),
+              ])),
+          Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(children: [
+                const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                        "File Path Pattern (for automatic file selection): ")),
+                TextField(
+                  controller: _filePathPatternController,
+                  decoration: const InputDecoration(
+                    hintText: "e.g. {vault}/Daily notes/{yyyy-MM-dd}.md",
+                  ),
+                  onSubmitted: (value) {
+                    widget.controller
+                        .updateFilePathPattern(value.isEmpty ? null : value);
+                  },
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  "If specified, tasks will be saved to this file path instead of showing file picker. Use {vault} for vault root. Date patterns must be in brackets: {yyyy-MM-dd}, {yyyy}/{MM}/{dd}, etc.",
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Colors.grey[600],
+                  ),
+                ),
               ])),
           Padding(
               padding: const EdgeInsets.all(16),

--- a/lib/src/screens/task_editor/cubit/task_editor_cubit.dart
+++ b/lib/src/screens/task_editor/cubit/task_editor_cubit.dart
@@ -1,9 +1,11 @@
 import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:logger/logger.dart';
 import 'package:obsi/src/core/notification_manager.dart';
 import 'package:obsi/src/core/tasks/task.dart';
 import 'package:obsi/src/core/tasks/task_manager.dart';
+import 'package:obsi/src/core/tasks/task_source.dart';
 import 'package:obsi/src/screens/settings/settings_controller.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:path/path.dart' as p;
@@ -14,23 +16,71 @@ class TaskEditorCubit extends Cubit<TaskEditorState> {
   final String? _createTasksPath;
   final Task _currentTask;
   String? _currentDescription;
+  bool _chooseFileEnabled = false;
+  bool _taskNoteFormat = false;
 
   TaskEditorCubit(this._taskManager, {Task? task, String? createTasksPath})
       : _createTasksPath = createTasksPath,
         _currentTask = task ?? Task(""),
         _currentDescription = task?.description,
-        super(TaskEditorInitial(task));
+        super(TaskEditorInitial(task)) {
+    _chooseFileEnabled = SettingsController.getInstance().chooseFileEnabled;
+  }
+
+  bool get chooseFileEnabled => _chooseFileEnabled;
+  bool get taskNoteFormat => _taskNoteFormat;
+  bool get isNewTask => _currentTask.taskSource == null;
+
+  void toggleChooseFile(bool value) {
+    _chooseFileEnabled = value;
+    SettingsController.getInstance().updateChooseFileEnabled(value);
+    emit(TaskEditorInitial(_currentTask));
+  }
+
+  void toggleTaskNoteFormat(bool value) {
+    _taskNoteFormat = value;
+    emit(TaskEditorInitial(_currentTask));
+  }
 
   Future<void> saveTask(BuildContext context) async {
     try {
       _currentTask.description = _currentDescription;
-      await _taskManager.saveTask(_currentTask, filePath: _createTasksPath);
 
-      Navigator.pop(context);
-    } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error: $e')),
+      String? filePath = _createTasksPath;
+      String? saveMarker;
+
+      if (isNewTask && _taskNoteFormat) {
+        filePath = await _handleTaskNoteFormat(context);
+        if (filePath == null) {
+          return;
+        }
+      } else if (isNewTask && _chooseFileEnabled) {
+        final result = await _handleChooseFile(context);
+        if (result == null) {
+          return;
+        }
+        filePath = result.$1;
+        saveMarker = result.$2;
+      } else if (_createTasksPath != null) {
+        saveMarker = SettingsController.getInstance().saveMarker;
+      }
+
+      await _taskManager.saveTask(
+        _currentTask,
+        filePath: filePath,
+        saveMarker: saveMarker,
       );
+
+      if (context.mounted) {
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      Logger().e('Error saving task: $e');
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error saving task: $e')),
+        );
+      }
     }
   }
 
@@ -125,20 +175,124 @@ class TaskEditorCubit extends Cubit<TaskEditorState> {
     emit(TaskEditorInitial(_currentTask));
   }
 
-  String _getSubstringAfter(String source) {
-    var settings = SettingsController.getInstance();
-    var vaultDirectory = settings.vaultDirectory;
-    if (vaultDirectory != null) {
-      int index = source.indexOf(vaultDirectory!);
-      if (index == -1) {
-        // If the search string is not found, return an empty string or handle it as needed
-        return '';
-      }
-      // Add the length of the search string to get the start index of the substring after the found substring
-      return source.substring(index + vaultDirectory!.length);
-    } else {
-      return source;
+  Future<(String?, String?)?> _handleChooseFile(BuildContext context) async {
+    final vaultDirectory = SettingsController.getInstance().vaultDirectory;
+    if (vaultDirectory == null) {
+      throw Exception('Please configure vault directory in settings');
     }
+
+    final filePathPattern = SettingsController.getInstance().filePathPattern;
+    final saveMarker = SettingsController.getInstance().saveMarker;
+
+    if (filePathPattern != null && filePathPattern.isNotEmpty) {
+      // Use pattern with date formatting instead of file picker
+      final filePath = _formatFilePathPattern(filePathPattern, vaultDirectory);
+      return (filePath, saveMarker);
+    }
+
+    // Show file picker dialog
+    final lastSelectedFile = SettingsController.getInstance().lastSelectedFile;
+    String? startDirectory = vaultDirectory;
+
+    // If there was a previously selected file, use its directory
+    if (lastSelectedFile != null && lastSelectedFile.isNotEmpty) {
+      final lastSlashIndex = lastSelectedFile.lastIndexOf('/');
+      if (lastSlashIndex > 0) {
+        startDirectory = lastSelectedFile.substring(0, lastSlashIndex);
+      }
+    }
+
+    final selectedPath = await SettingsController.selectFile(
+      context,
+      startDirectory: startDirectory,
+    );
+
+    if (selectedPath == null) {
+      return null;
+    }
+
+    // Save the selected file path for next time
+    await SettingsController.getInstance().updateLastSelectedFile(selectedPath);
+
+    return (selectedPath, saveMarker);
+  }
+
+  Future<String?> _handleTaskNoteFormat(BuildContext context) async {
+    final selectedFolder =
+        await SettingsController.selectVaultDirectory(context);
+
+    if (selectedFolder == null) {
+      return null;
+    }
+
+    // Generate filename from description (max 15 characters)
+    if (_currentDescription == null || _currentDescription!.trim().isEmpty) {
+      throw Exception('Task description cannot be empty for TaskNote format');
+    }
+
+    String filename = _currentDescription!.trim();
+    // Take first 15 characters and sanitize
+    if (filename.length > 15) {
+      filename = filename.substring(0, 15);
+    }
+    // Remove invalid filename characters
+    filename = filename.replaceAll(RegExp(r'[/\\:*?"<>|]'), '_');
+
+    final filePath = p.join(selectedFolder, '\$filename.md');
+
+    // Set task source type to TaskNote
+    _currentTask.taskSource = TaskSource(
+      0, // fileNumber
+      filePath, // fileName
+      0, // offset
+      0, // length
+      type: TaskType.taskNote, // type
+    );
+
+    return filePath;
+  }
+
+  String _formatFilePathPattern(String pattern, String vaultDirectory) {
+    final now = DateTime.now();
+    final buffer = StringBuffer();
+    int i = 0;
+
+    while (i < pattern.length) {
+      if (pattern[i] == '{') {
+        // Find the closing bracket
+        final closeIndex = pattern.indexOf('}', i);
+        if (closeIndex == -1) {
+          // No closing bracket, treat as literal
+          buffer.write(pattern[i]);
+          i++;
+          continue;
+        }
+
+        // Extract content between brackets
+        final content = pattern.substring(i + 1, closeIndex);
+
+        if (content == 'vault') {
+          // Replace with vault directory
+          buffer.write(vaultDirectory);
+        } else {
+          // Treat as date format pattern
+          try {
+            buffer.write(DateFormat(content).format(now));
+          } catch (e) {
+            // If invalid format, keep original
+            buffer.write('{$content}');
+          }
+        }
+
+        i = closeIndex + 1;
+      } else {
+        // Regular character, copy as-is
+        buffer.write(pattern[i]);
+        i++;
+      }
+    }
+
+    return buffer.toString();
   }
 
   Future<void> launchObsidian(BuildContext context) async {

--- a/lib/src/screens/task_editor/task_editor.dart
+++ b/lib/src/screens/task_editor/task_editor.dart
@@ -72,7 +72,22 @@ class _TaskEditorState extends State<TaskEditor> {
                                   .setDescription(value);
                             },
                           ),
-                          const SizedBox(height: 12),
+                          if (context.read<TaskEditorCubit>().isNewTask)
+                            CheckboxListTile(
+                              title: const Text('TaskNote format'),
+                              value: context
+                                  .read<TaskEditorCubit>()
+                                  .taskNoteFormat,
+                              onChanged: (value) {
+                                if (value != null) {
+                                  context
+                                      .read<TaskEditorCubit>()
+                                      .toggleTaskNoteFormat(value);
+                                }
+                              },
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: EdgeInsets.zero,
+                            ),
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
@@ -331,19 +346,49 @@ class _TaskEditorState extends State<TaskEditor> {
                     ],
                   ),
                 ),
-                // Bottom save button
+                // Bottom save button with optional file chooser checkbox
                 SafeArea(
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-                    child: SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton.icon(
-                        icon: const Icon(Icons.save_outlined),
-                        label: const Text('Save'),
-                        onPressed: () {
-                          context.read<TaskEditorCubit>().saveTask(context);
-                        },
-                      ),
+                    child: Row(
+                      children: [
+                        if (context.read<TaskEditorCubit>().isNewTask &&
+                            !context.read<TaskEditorCubit>().taskNoteFormat)
+                          Expanded(
+                            flex: 1,
+                            child: CheckboxListTile(
+                              title: const Text('Choose file'),
+                              value: context
+                                  .read<TaskEditorCubit>()
+                                  .chooseFileEnabled,
+                              onChanged: (value) {
+                                if (value != null) {
+                                  context
+                                      .read<TaskEditorCubit>()
+                                      .toggleChooseFile(value);
+                                }
+                              },
+                              controlAffinity: ListTileControlAffinity.leading,
+                              contentPadding: EdgeInsets.zero,
+                            ),
+                          ),
+                        Expanded(
+                          flex: 1,
+                          child: SizedBox(
+                            height: 40,
+                            child: ElevatedButton.icon(
+                              icon: const Icon(Icons.save_outlined, size: 18),
+                              label: const Text('Save',
+                                  style: TextStyle(fontSize: 14)),
+                              onPressed: () {
+                                context
+                                    .read<TaskEditorCubit>()
+                                    .saveTask(context);
+                              },
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 )


### PR DESCRIPTION
1. Option TaskNote, when it is chosen then save button opens folder selection dialog and save with file name - beginning of description
2. For markdown task, it is possible to choose file for saving
3. For markdown task, it is possible to use pattern for file selection and marker for saving inside the file. It is specified in settings. File pattern supports {vault}/{yyyy-MM} which is updated with current vault and date during saving. If pattern is not specified then default file for tasks is used