### PR TITLE
fix: use ISO 8601 "T" separator in scheduled datetime instead of "N"

### DIFF
--- a/lib/src/core/tasks/savers/task_note_saver.dart
+++ b/lib/src/core/tasks/savers/task_note_saver.dart
@@ -59,7 +59,7 @@ tags:
     }
   }
 
-  /// Formats scheduled date as YYYY-MM-DD or YYYY-MM-DDNHH:MM:SS
+  /// Formats scheduled date as YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS
   String _formatScheduledDate(DateTime? date, bool includeTime) {
     if (date == null) {
       return '';
@@ -69,7 +69,7 @@ tags:
       // Format as YYYY-MM-DDNHH:MM:SS
       final dateStr = DateFormat('yyyy-MM-dd').format(date);
       final timeStr = DateFormat('HH:mm:ss').format(date);
-      return '${dateStr}N$timeStr';
+      return '${dateStr}T$timeStr';
     } else {
       // Format as YYYY-MM-DD
       return DateFormat('yyyy-MM-dd').format(date);

--- a/test/task_note_saver_test.dart
+++ b/test/task_note_saver_test.dart
@@ -226,7 +226,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-11-03N19:00:00'));
+        expect(result, contains('scheduled: 2025-11-03T19:00:00'));
       });
 
       test('should format scheduled date with different time values', () {
@@ -241,7 +241,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2024-12-25N08:30:45'));
+        expect(result, contains('scheduled: 2024-12-25T08:30:45'));
       });
 
       test('should format scheduled date with midnight time', () {
@@ -256,7 +256,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-01-01N00:00:00'));
+        expect(result, contains('scheduled: 2025-01-01T00:00:00'));
       });
 
       test('should format scheduled date with end of day time', () {
@@ -271,7 +271,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-06-15N23:59:59'));
+        expect(result, contains('scheduled: 2025-06-15T23:59:59'));
       });
 
       test('should handle null scheduled date', () {
@@ -336,7 +336,7 @@ void main() {
         final savedContent = saver.toTaskNoteString(task);
 
         // Verify the saved format includes time
-        expect(savedContent, contains('scheduled: 2025-11-03N19:30:45'));
+        expect(savedContent, contains('scheduled: 2025-11-03T19:30:45'));
         expect(savedContent, contains('---'));
         expect(savedContent, contains('Task with time'));
       });


### PR DESCRIPTION
## Description

Fixes #35 — notifications were failing because VaultMate wrote datetime with `N` separator (e.g. `2026-06-27N14:40:17`) instead of the ISO 8601 standard `T`.

The Flutter/Android notification system expects the standard `T` separator.

## Changes

**lib/src/core/tasks/savers/task_note_saver.dart**

- `_formatScheduledDate()`: replaced `N` with `T` in date-with-time format
- Updated the corresponding doc comment

## Verification

- `DateTime.tryParse("2026-06-27T14:40:17")` — works
- `DateTime.tryParse("2026-06-27N14:40:17")` — returns null

The parser (`_parseScheduledDate` in task_note_parser.dart) is left unchanged — it supports both formats for backward compatibility with existing files that may have `N` saved.