### PR TITLE
fix: preserve newlines in task description when parsing tags

### DIFF
--- a/lib/src/core/tasks/task.dart
+++ b/lib/src/core/tasks/task.dart
@@ -109,8 +109,8 @@ class Task implements Comparable<Task> {
 
       // Remove hashtags from description
       _description = _description!.replaceAll(tagRegex, ' ').trim();
-      // Clean up multiple spaces that might result from tag removal
-      _description = _description!.replaceAll(RegExp(r'\s+'), ' ').trim();
+      // Clean up multiple spaces that might result from tag removal, preserving newlines
+      _description = _description!.replaceAll(RegExp(r'[^\S\n]+'), ' ').trim();
       _tags.addAll(tags);
     }
   }

--- a/test/task_note_saver_test.dart
+++ b/test/task_note_saver_test.dart
@@ -226,7 +226,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-11-03T19:00:00'));
+        expect(result, contains('scheduled: 2025-11-03N19:00:00'));
       });
 
       test('should format scheduled date with different time values', () {
@@ -241,7 +241,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2024-12-25T08:30:45'));
+        expect(result, contains('scheduled: 2024-12-25N08:30:45'));
       });
 
       test('should format scheduled date with midnight time', () {
@@ -256,7 +256,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-01-01T00:00:00'));
+        expect(result, contains('scheduled: 2025-01-01N00:00:00'));
       });
 
       test('should format scheduled date with end of day time', () {
@@ -271,7 +271,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-06-15T23:59:59'));
+        expect(result, contains('scheduled: 2025-06-15N23:59:59'));
       });
 
       test('should handle null scheduled date', () {
@@ -336,7 +336,7 @@ void main() {
         final savedContent = saver.toTaskNoteString(task);
 
         // Verify the saved format includes time
-        expect(savedContent, contains('scheduled: 2025-11-03T19:30:45'));
+        expect(savedContent, contains('scheduled: 2025-11-03N19:30:45'));
         expect(savedContent, contains('---'));
         expect(savedContent, contains('Task with time'));
       });

--- a/test/task_note_saver_test.dart
+++ b/test/task_note_saver_test.dart
@@ -226,7 +226,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-11-03N19:00:00'));
+        expect(result, contains('scheduled: 2025-11-03T19:00:00'));
       });
 
       test('should format scheduled date with different time values', () {
@@ -241,7 +241,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2024-12-25N08:30:45'));
+        expect(result, contains('scheduled: 2024-12-25T08:30:45'));
       });
 
       test('should format scheduled date with midnight time', () {
@@ -256,7 +256,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-01-01N00:00:00'));
+        expect(result, contains('scheduled: 2025-01-01T00:00:00'));
       });
 
       test('should format scheduled date with end of day time', () {
@@ -271,7 +271,7 @@ void main() {
 
         final result = saver.toTaskNoteString(task);
 
-        expect(result, contains('scheduled: 2025-06-15N23:59:59'));
+        expect(result, contains('scheduled: 2025-06-15T23:59:59'));
       });
 
       test('should handle null scheduled date', () {
@@ -336,7 +336,7 @@ void main() {
         final savedContent = saver.toTaskNoteString(task);
 
         // Verify the saved format includes time
-        expect(savedContent, contains('scheduled: 2025-11-03N19:30:45'));
+        expect(savedContent, contains('scheduled: 2025-11-03T19:30:45'));
         expect(savedContent, contains('---'));
         expect(savedContent, contains('Task with time'));
       });


### PR DESCRIPTION
## Description

Fixes #34 — structured markdown (lists, tags on new lines) was collapsing into a single line in the VaultMate editor.

## Root Cause

In Task._parseTags() at line 113, the regex \s+ replaced ALL whitespace (including \n) with a single space, destroying line breaks.

## Changes

**lib/src/core/tasks/task.dart**

- \s+ replaced with [^\S\n]+ — whitespace EXCEPT newline
- Line breaks in task descriptions are now preserved

## Example

Before (in Obsidian):
```
Bring something
#help
1. pop offffff
2. do
```

After (in editor, before fix):
```
Bring something 1. pop offffff 2. do
```

After (with fix):
```
Bring something
1. pop offffff
2. do
```
