### PR TITLE
fix: skip trailing space when priority is normal

### DIFF
--- a/lib/src/core/tasks/task_parser.dart
+++ b/lib/src/core/tasks/task_parser.dart
@@ -351,7 +351,9 @@ class TaskParser extends MarkdownTaskMarkers {
       serializedTask += " (@$time)";
     }
 
-    serializedTask += ' ${getPriorityMarker(task.priority)}';
+    if (task.priority != TaskPriority.normal) {
+      serializedTask += ' ${getPriorityMarker(task.priority)}';
+    }
 
     serializedTask += _saveDate(
         MarkdownTaskMarkers.createdDateMarker, dateTemplate, task.created);


### PR DESCRIPTION
## Problem

When a task has normal priority (no emoji), toTaskString() added a trailing space. This caused the test 'read tasks and re-save 1 task without changes' to fail.

## Fix

Only prepend space before priority emoji when priority is not normal.