### PR TITLE
chore: bump AGP to 9.2.0 for glance library compatibility

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.11.1' apply false
+    id "com.android.application" version '9.2.0' apply false
     id "org.jetbrains.kotlin.android" version "2.2.20-RC" apply false
     id "org.jetbrains.kotlin.plugin.compose" version "2.2.20-RC" apply false
 }


### PR DESCRIPTION
## Problem

Build fails with:
```
Dependency 'androidx.glance:glance-appwidget:1.3.0-alpha02' requires Android Gradle plugin 9.1.0 or higher.
This build currently uses Android Gradle plugin 8.11.1.
```

## Fix

Bump Android Gradle Plugin from 8.11.1 to 9.2.0 (latest stable, April 2026).
Gradle 8.13 already in place — compatible with AGP 9.x.