### PR TITLE
chore: bump Gradle to 9.4.1 for AGP 9.2.0 compatibility

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip


### PR DESCRIPTION
## Problem

AGP 9.2.0 requires Gradle 9.4.1 or higher. Current Gradle is 8.13.

```
Minimum supported Gradle version is 9.4.1. Current version is 8.13.
```

## Fix

Bump Gradle wrapper from 8.13 to 9.4.1.