### PR TITLE
fix: remove kotlin.plugin.compose for AGP 9.2.0 compatibility

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -21,7 +21,6 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '9.2.0' apply false
     id "org.jetbrains.kotlin.android" version "2.2.20-RC" apply false
-    id "org.jetbrains.kotlin.plugin.compose" version "2.2.20-RC" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Problem

Build fails with AGP 9.2.0:
```
Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
```

Root cause: AGP 9.x has built-in Compose support, so the explicit `kotlin.plugin.compose` plugin conflicts.

## Fix

Remove `kotlin.plugin.compose` from settings.gradle. AGP 9.2.0 handles Compose compilation natively.