### PR TITLE
fix: create next occurrence when recurring task completed from widget

### DIFF
--- a/android/app/src/main/kotlin/com/scanworks/obsi/TasksWidget/RecurrenceCalculator.kt
+++ b/android/app/src/main/kotlin/com/scanworks/obsi/TasksWidget/RecurrenceCalculator.kt
@@ -1,0 +1,59 @@
+package com.scanworks.obsi
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+/**
+ * Kotlin port of [RecurrentTask.calculateNextOccurrence] (lib/src/core/tasks/reccurent_task.dart)
+ * so the home-screen widget can compute the next occurrence of a recurring task without
+ * round-tripping through the Dart isolate. Keep in sync with the Dart implementation.
+ */
+object RecurrenceCalculator {
+    private val weekdayNames = mapOf(
+        "monday" to DayOfWeek.MONDAY,
+        "tuesday" to DayOfWeek.TUESDAY,
+        "wednesday" to DayOfWeek.WEDNESDAY,
+        "thursday" to DayOfWeek.THURSDAY,
+        "friday" to DayOfWeek.FRIDAY,
+        "saturday" to DayOfWeek.SATURDAY,
+        "sunday" to DayOfWeek.SUNDAY
+    )
+
+    fun calculateNextOccurrence(lastDate: LocalDate, recurrenceRule: String): LocalDate {
+        val ruleParts = recurrenceRule.trim().split(Regex("\\s+"))
+        if (ruleParts.size < 2 || ruleParts[0].lowercase() != "every") {
+            throw IllegalArgumentException("Invalid recurrence rule format.")
+        }
+
+        val frequency = ruleParts[1].lowercase()
+        val interval = if (ruleParts.size == 3) ruleParts[2].toIntOrNull() ?: 1 else 1
+
+        return when (frequency) {
+            "day", "days" -> lastDate.plusDays(interval.toLong())
+            "week", "weeks" -> lastDate.plusWeeks(interval.toLong())
+            "month", "months" -> lastDate.plusMonths(interval.toLong())
+            "year", "years" -> lastDate.plusYears(interval.toLong())
+            "weekday", "weekdays" -> {
+                var nextDate = lastDate
+                repeat(interval) {
+                    nextDate = nextDate.plusDays(1)
+                    while (nextDate.dayOfWeek == DayOfWeek.SATURDAY ||
+                        nextDate.dayOfWeek == DayOfWeek.SUNDAY
+                    ) {
+                        nextDate = nextDate.plusDays(1)
+                    }
+                }
+                nextDate
+            }
+            else -> {
+                val weekday = weekdayNames[frequency]
+                    ?: throw IllegalArgumentException("Unsupported recurrence frequency.")
+                var nextDate = lastDate.plusDays(1)
+                while (nextDate.dayOfWeek != weekday) {
+                    nextDate = nextDate.plusDays(1)
+                }
+                nextDate
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/scanworks/obsi/TasksWidget/TaskWrapper.kt
+++ b/android/app/src/main/kotlin/com/scanworks/obsi/TasksWidget/TaskWrapper.kt
@@ -1,4 +1,5 @@
 package com.scanworks.obsi
+import org.json.JSONArray
 import org.json.JSONObject
 
 data class TaskWrapper(
@@ -13,7 +14,8 @@ data class TaskWrapper(
     val scheduled: String? = null,
     val recurrenceRule: String? = null,
     val filePath: String? = null,
-    val fileOffset: String? = null
+    val fileOffset: String? = null,
+    val tags: List<String> = emptyList()
 ) {
     fun toJsonObject(): JSONObject {
         return JSONObject().apply {
@@ -29,6 +31,7 @@ data class TaskWrapper(
             put("recurrenceRule", recurrenceRule)
             put("filePath", filePath)
             put("fileOffset", fileOffset)
+            put("tags", JSONArray(tags))
         }
     }
 
@@ -86,9 +89,20 @@ data class TaskWrapper(
 
             android.util.Log.d(TAG, "Updated line: '$newLine'")
 
+            // If this completes a recurring task, insert a new task line for the next occurrence,
+            // mirroring TaskManager._manageRecurrentTask on the Dart side.
+            val recurringLine = if (done) buildNextOccurrenceLine() else null
+            if (recurringLine != null) {
+                android.util.Log.d(TAG, "Next occurrence line: '$recurringLine'")
+            }
+
             // Replace the line in the content
             val newContent = buildString {
                 append(content.substring(0, lineStart))
+                if (recurringLine != null) {
+                    append(recurringLine)
+                    append("\n")
+                }
                 append(newLine)
                 append(content.substring(lineEndFinal))
             }
@@ -100,8 +114,45 @@ data class TaskWrapper(
             return false
         }
     }
-  
+
+    /**
+     * If this task is recurring and scheduled, builds the markdown line for its next
+     * occurrence (mirroring TaskManager._manageRecurrentTask / RecurrentTask.calculateNextOccurrence
+     * on the Dart side). Returns null if the task is not recurring, has no scheduled date,
+     * or the recurrence rule can't be parsed.
+     */
+    private fun buildNextOccurrenceLine(): String? {
+        val rule = recurrenceRule
+        if (rule.isNullOrBlank() || scheduled.isNullOrBlank()) {
+            return null
+        }
+        return try {
+            val lastDate = java.time.LocalDate.parse(scheduled.substring(0, 10))
+            val nextDate = RecurrenceCalculator.calculateNextOccurrence(lastDate, rule)
+            val today = java.time.LocalDate.now().toString()
+
+            val tagsSuffix = if (tags.isNotEmpty()) tags.joinToString("") { " #$it" } else ""
+            val prioritySuffix = priorityMarker(priority)?.let { " $it" } ?: ""
+
+            "- [ ] $description$tagsSuffix$prioritySuffix ➕ $today ⏳ $nextDate 🔁 $rule"
+        } catch (e: Exception) {
+            android.util.Log.w("TaskWrapper", "Could not compute next occurrence for rule '$rule'", e)
+            null
+        }
+    }
+
     companion object {
+        private fun priorityMarker(priority: String): String? {
+            return when (priority.lowercase()) {
+                "lowest" -> "⏬"
+                "low" -> "🔽"
+                "medium" -> "🔼"
+                "high" -> "⏫"
+                "highest" -> "🔺"
+                else -> null
+            }
+        }
+
     private fun updateLineWithStatus(line: String, done: Boolean, statusRegex: Regex): String {
         return if (done) {
             // Add done date in yyyy-MM-dd format with prefix ✅ at the end
@@ -115,6 +166,12 @@ data class TaskWrapper(
         }
     }
         fun fromJson(obj: JSONObject): TaskWrapper {
+            val tagsArray = obj.optJSONArray("tags")
+            val tags = if (tagsArray != null) {
+                List(tagsArray.length()) { i -> tagsArray.optString(i) }
+            } else {
+                emptyList()
+            }
             return TaskWrapper(
                 description = obj.optString("description", ""),
                 status = obj.optString("status", "todo"),
@@ -127,7 +184,8 @@ data class TaskWrapper(
                 scheduled = obj.optString("scheduled", null),
                 recurrenceRule = obj.optString("recurrenceRule", null),
                 filePath = obj.optString("filePath", null),
-                fileOffset = obj.optString("fileOffset", null)
+                fileOffset = obj.optString("fileOffset", null),
+                tags = tags
             )
         }
     }


### PR DESCRIPTION
## Summary
- The home-screen widget's checkbox action (`TaskCheckActionCallback` -> `TaskWrapper.updateTaskStatusInFile`) toggled the checkbox by directly regex-editing the markdown file in native Kotlin, completely bypassing `TaskManager._manageRecurrentTask` (the Dart logic that creates the next occurrence). Marking a recurring task done from the widget silently dropped the recurrence, while completing it inside the app worked fine.
- Ported `RecurrentTask.calculateNextOccurrence` to Kotlin (`RecurrenceCalculator.kt`).
- When a task with a `recurrenceRule` and a `scheduled` date is completed from the widget, a new todo line for the next occurrence is now inserted alongside the completed line, using the same field order (`➕ created  ⏳ scheduled  🔁 rule`) the Dart `TaskParser.toTaskString` produces.
- Also fixed `TaskWrapper` silently dropping the `tags` field sent from the Dart side (it's included in `Task.toJsonMap()` but was never read), so tags now carry over to the newly created occurrence.

Fixes #3

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [ ] Manual: add a daily recurring task in the vault, mark it done from the home-screen widget, confirm a new todo line for tomorrow appears in the file and the widget reflects it (not verified on-device, no emulator available in this session)
- [ ] Manual: verify unchecking a task from the widget still works and does not create a duplicate occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)