### PR TITLE
ci: only build Android bundle on release tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,12 @@ jobs:
 
   build_android:
     name: "Build Android release"
-    # Only build on main or version tags like v1.2.3, or when manually triggered
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    # Only build on version tags like v1.2.3, or when manually triggered.
+    # A release push lands the version bump on main *and* tags that same
+    # commit, so also building on plain main pushes would build the
+    # identical commit twice for no benefit (the release job below only
+    # ever runs off the tag anyway).
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- `build_android` was running on both the `main` push (version bump commit) and the subsequent tag push for every release, building the identical commit twice.
- The `release` job only ever runs off the tag anyway, so the main-push build was pure waste (~8-9 min of CI time per release).
- Drops `github.ref == 'refs/heads/main'` from `build_android`'s condition; it now only builds on `v*` tags or manual dispatch. `run_tests` is unaffected and still runs on every push/PR.

## Test plan
- [x] Reviewed the workflow YAML change locally.
- [x] Merge and confirm the next `main` push (non-tag) does not trigger `build_android`, while the next tag push still does.