### PR TITLE
fix: delete file entirely when a TaskNote task is removed

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -36,6 +36,8 @@ import UIKit
                 self.handleFileRead(arguments: call.arguments, result: result)
             case "TaskFileWriteAsString":
                 self.handleFileWrite(arguments: call.arguments, result: result)
+            case "TaskFileDelete":
+                self.handleFileDelete(arguments: call.arguments, result: result)
             default:
                 result(FlutterMethodNotImplemented)
             }
@@ -116,6 +118,21 @@ import UIKit
         let fileURL = URL(fileURLWithPath: filePath)
         if let error = FileService.writeFileContent(fileURL, content: content) {
             result(FlutterError(code: "WRITE_ERROR", message: "Failed to write file: \(error.localizedDescription)", details: nil))
+        } else {
+            result(nil)
+        }
+    }
+    
+    private func handleFileDelete(arguments: Any?, result: @escaping FlutterResult) {
+        guard let args = arguments as? [String: Any],
+              let filePath = args["filePath"] as? String else {
+            result(FlutterError(code: "INVALID_ARGUMENT", message: "Missing file path", details: nil))
+            return
+        }
+        
+        let fileURL = URL(fileURLWithPath: filePath)
+        if let error = FileService.deleteFile(fileURL) {
+            result(FlutterError(code: "DELETE_ERROR", message: "Failed to delete file: \(error.localizedDescription)", details: nil))
         } else {
             result(nil)
         }

--- a/ios/Runner/FileManager+Extensions.swift
+++ b/ios/Runner/FileManager+Extensions.swift
@@ -144,4 +144,24 @@ class FileService {
         }
         return nil // File already exists, consider it a success
     }
+    
+    static func deleteFile(_ fileURL: URL) -> Error? {
+        let success = fileURL.startAccessingSecurityScopedResource()
+        defer {
+            if success {
+                fileURL.stopAccessingSecurityScopedResource()
+            }
+        }
+        
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return nil // Nothing to delete, consider it a success
+        }
+        do {
+            try fileManager.removeItem(at: fileURL)
+            return nil
+        } catch {
+            return error
+        }
+    }
 } 

--- a/lib/src/core/storage/android_tasks_file_storage.dart
+++ b/lib/src/core/storage/android_tasks_file_storage.dart
@@ -13,6 +13,13 @@ class AndroidTasksFile implements TasksFile {
   }
 
   @override
+  Future<void> delete() async {
+    if (await _file.exists()) {
+      await _file.delete();
+    }
+  }
+
+  @override
   Future<bool> exists() async {
     return await _file.exists();
   }

--- a/lib/src/core/storage/ios_tasks_file_storage.dart
+++ b/lib/src/core/storage/ios_tasks_file_storage.dart
@@ -19,6 +19,17 @@ class IosTasksFile implements TasksFile {
   }
 
   @override
+  Future<void> delete() async {
+    try {
+      await _platform.invokeMethod('TaskFileDelete', {
+        'filePath': path,
+      });
+    } on PlatformException catch (e) {
+      throw Exception('Failed to delete file: ${e.message}');
+    }
+  }
+
+  @override
   Future<bool> exists() async {
     try {
       final bool exists = await _platform.invokeMethod('TaskFileExists', {

--- a/lib/src/core/storage/storage_interfaces.dart
+++ b/lib/src/core/storage/storage_interfaces.dart
@@ -10,6 +10,7 @@ abstract class TasksFile {
   Future<void> writeAsString(String content);
   Future<bool> exists();
   Future<void> create();
+  Future<void> delete();
 }
 
 abstract class TasksFileStorage {

--- a/lib/src/core/tasks/task_manager.dart
+++ b/lib/src/core/tasks/task_manager.dart
@@ -371,6 +371,29 @@ class TaskManager with ChangeNotifier {
 
     var newContent =
         content.substring(0, lineStart) + content.substring(lineEnd);
+
+    // If the file becomes empty after removing the task (e.g. a TaskNote
+    // file that contained only this task), delete the file entirely instead
+    // of leaving an empty shell behind (issue #60).
+    if (newContent.trim().isEmpty) {
+      await file.delete();
+      var updatedTasks = Parser.parseTasks(source.fileName, '',
+          fileNumber: source.fileNumber, taskFilter: _taskFilter);
+
+      var indexOfFirstTaskFromFile =
+          _tasks.indexWhere((val) => val.taskSource!.fileName == source.fileName);
+      if (indexOfFirstTaskFromFile == -1) {
+        indexOfFirstTaskFromFile = 0;
+      } else {
+        _tasks.removeWhere((val) => val.taskSource!.fileName == source.fileName);
+      }
+
+      _addFilteredTasks(_tasks, updatedTasks, todoOnly, forDateOnly,
+          position: indexOfFirstTaskFromFile);
+      notifyListeners();
+      return;
+    }
+
     await file.writeAsString(newContent);
 
     var updatedTasks = Parser.parseTasks(source.fileName, newContent,

--- a/lib/src/core/tasks/task_manager.dart
+++ b/lib/src/core/tasks/task_manager.dart
@@ -8,6 +8,7 @@ import 'package:obsi/src/core/storage/storage_interfaces.dart';
 import 'package:obsi/src/core/tasks/parsers/parser.dart';
 import 'package:obsi/src/core/tasks/reccurent_task.dart';
 import 'package:obsi/src/core/tasks/task.dart';
+import 'package:obsi/src/core/tasks/task_source.dart';
 import 'package:obsi/src/core/tasks/savers/task_saver.dart';
 import 'package:obsi/src/core/tasks/task_worker.dart';
 import 'package:tuple/tuple.dart';

--- a/lib/src/core/tasks/task_manager.dart
+++ b/lib/src/core/tasks/task_manager.dart
@@ -356,6 +356,17 @@ class TaskManager with ChangeNotifier {
     }
 
     var file = storage.getFile(source.fileName);
+
+    // A TaskNote task lives in its own file — the whole file IS the task.
+    // Delete the file entirely instead of leaving an empty shell behind
+    // (issue #60).
+    if (source.type == TaskType.taskNote) {
+      await file.delete();
+      _tasks.removeWhere((val) => val.taskSource?.fileName == source.fileName);
+      notifyListeners();
+      return;
+    }
+
     var content = await file.readAsString();
 
     // Remove the whole line (including any leading indentation before the
@@ -371,28 +382,6 @@ class TaskManager with ChangeNotifier {
 
     var newContent =
         content.substring(0, lineStart) + content.substring(lineEnd);
-
-    // If the file becomes empty after removing the task (e.g. a TaskNote
-    // file that contained only this task), delete the file entirely instead
-    // of leaving an empty shell behind (issue #60).
-    if (newContent.trim().isEmpty) {
-      await file.delete();
-      var updatedTasks = Parser.parseTasks(source.fileName, '',
-          fileNumber: source.fileNumber, taskFilter: _taskFilter);
-
-      var indexOfFirstTaskFromFile =
-          _tasks.indexWhere((val) => val.taskSource!.fileName == source.fileName);
-      if (indexOfFirstTaskFromFile == -1) {
-        indexOfFirstTaskFromFile = 0;
-      } else {
-        _tasks.removeWhere((val) => val.taskSource!.fileName == source.fileName);
-      }
-
-      _addFilteredTasks(_tasks, updatedTasks, todoOnly, forDateOnly,
-          position: indexOfFirstTaskFromFile);
-      notifyListeners();
-      return;
-    }
 
     await file.writeAsString(newContent);
 

--- a/test/in_memory_tasks_file_storage.dart
+++ b/test/in_memory_tasks_file_storage.dart
@@ -32,6 +32,15 @@ class InMemoryTasksFile implements TasksFile {
   }
 
   @override
+  Future<void> delete() async {
+    _content = '';
+    _deleted = true;
+  }
+
+  bool _deleted = false;
+  bool get isDeleted => _deleted;
+
+  @override
   String toString() {
     return _path;
   }

--- a/test/task_manager_tasknote_test.dart
+++ b/test/task_manager_tasknote_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:obsi/src/core/tasks/task_manager.dart';
 import 'package:obsi/src/core/tasks/task.dart';
+import 'package:obsi/src/core/tasks/task_source.dart';
 import 'package:path/path.dart' as p;
 import 'in_memory_tasks_file_storage.dart';
 
@@ -346,6 +347,60 @@ this is a tasknote
       var regularTasks =
           manager.tasks.where((t) => t.tags.contains('regular')).toList();
       expect(regularTasks.length, equals(3));
+    });
+
+    test('deleteTask deletes the whole file when a TaskNote task is deleted',
+        () async {
+      var storage = InMemoryTasksFileStorage();
+
+      // TaskNote file — the whole file IS the task
+      await storage.getFile('/TaskNote/delete_me.md').writeAsString('''---
+status: open
+priority: high
+scheduled: 2025-08-16
+dateCreated: 2025-08-16T22:33:28.696+02:00
+dateModified: 2025-08-16T22:33:28.696+02:00
+tags:
+  - task
+---
+
+task to delete
+''');
+
+      // Regular markdown file with tasks — must NOT be deleted
+      await storage.getFile('/TaskNote/regular.md').writeAsString('''
+- [ ] regular task 1
+- [ ] regular task 2
+''');
+
+      var manager = TaskManager(storage);
+      await manager.loadTasks(p.dirname('/TaskNote/'));
+
+      expect(manager.tasks.length, equals(3));
+
+      var taskToDelete = manager.tasks
+          .firstWhere((t) => t.description == 'task to delete');
+      expect(taskToDelete.taskSource!.type, equals(TaskType.taskNote));
+
+      await manager.deleteTask(taskToDelete);
+
+      // The TaskNote file should be deleted entirely, not left empty
+      var deletedFile = storage.getFile('/TaskNote/delete_me.md');
+      expect(deletedFile.isDeleted, isTrue,
+          reason: 'TaskNote file should be deleted when its only task is removed');
+
+      // Sibling file with regular tasks must be untouched
+      expect(manager.tasks.any((t) => t.description == 'task to delete'),
+          isFalse);
+      expect(manager.tasks.any((t) => t.description == 'regular task 1'),
+          isTrue);
+      expect(manager.tasks.any((t) => t.description == 'regular task 2'),
+          isTrue);
+
+      var siblingContent =
+          await storage.getFile('/TaskNote/regular.md').readAsString();
+      expect(siblingContent, contains('regular task 1'));
+      expect(siblingContent, contains('regular task 2'));
     });
   });
 }

--- a/test/task_manager_tasknote_test.dart
+++ b/test/task_manager_tasknote_test.dart
@@ -384,7 +384,8 @@ task to delete
       await manager.deleteTask(taskToDelete);
 
       // The TaskNote file should be deleted entirely, not left empty
-      var deletedFile = storage.getFile('/TaskNote/delete_me.md');
+      var deletedFile =
+          storage.getFile('/TaskNote/delete_me.md') as InMemoryTasksFile;
       expect(deletedFile.isDeleted, isTrue,
           reason: 'TaskNote file should be deleted when its task is removed');
 

--- a/test/task_manager_tasknote_test.dart
+++ b/test/task_manager_tasknote_test.dart
@@ -349,8 +349,7 @@ this is a tasknote
       expect(regularTasks.length, equals(3));
     });
 
-    test('deleteTask deletes the whole file when a TaskNote task is deleted',
-        () async {
+    test('deleteTask deletes the whole file for a TaskNote task', () async {
       var storage = InMemoryTasksFileStorage();
 
       // TaskNote file — the whole file IS the task
@@ -387,7 +386,7 @@ task to delete
       // The TaskNote file should be deleted entirely, not left empty
       var deletedFile = storage.getFile('/TaskNote/delete_me.md');
       expect(deletedFile.isDeleted, isTrue,
-          reason: 'TaskNote file should be deleted when its only task is removed');
+          reason: 'TaskNote file should be deleted when its task is removed');
 
       // Sibling file with regular tasks must be untouched
       expect(manager.tasks.any((t) => t.description == 'task to delete'),


### PR DESCRIPTION
## Summary

Fixes #60 — deleting a TaskNote task removed only the task content, leaving an empty note file behind.

A TaskNote task lives in its own file — the whole file IS the task. Now `deleteTask` **deletes the file entirely** whenever the task type is `TaskNote`, unconditionally (no remaining-content check needed).

## Changes

- **`TaskManager.deleteTask`**: early-return branch — if `task.taskSource.type == TaskType.taskNote`, delete the file and remove the task from the in-memory list
- **`TasksFile` interface**: new `delete()` method
- **Android**: `AndroidTasksFile.delete()` → `File.delete()`
- **iOS**: new `TaskFileDelete` method-channel handler → `FileService.deleteFile()` (security-scoped resource access preserved)
- **Tests**: `InMemoryTasksFile` now tracks `isDeleted`; new unit test in `task_manager_tasknote_test.dart` verifies the TaskNote file is deleted while sibling regular-markdown files stay untouched

## Notes

- Regular markdown tasks (inline format) are unaffected — they keep the existing line-removal path
- CI runs `flutter test` on this PR